### PR TITLE
GPU with low memory 

### DIFF
--- a/image_classification_1.qmd
+++ b/image_classification_1.qmd
@@ -416,6 +416,7 @@ fitted <- convnet %>%
   fit(train_dl,
       epochs = 50,
       valid_data = valid_dl,
+      accelerator = accelerator(cpu = TRUE),
       verbose = TRUE
       )
 


### PR DESCRIPTION
I can't use GPU with low memory to execute the luz convnet example, so I updated image_classification_1.qmd adding the accelerator paramter to the fit function, 